### PR TITLE
Add About page with Giorgio-style monologue and music

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About — Glauber Ramos</title>
+    <meta name="description" content="About Glauber Ramos, indiehacker from Brazil." />
+  </head>
+
+  <body>
+    <div class="page">
+      <h1>About</h1>
+
+      <div class="monologue">
+        <p>
+          When I was 17, when I really started to write code<br />
+          I definitely wanted to build products of my own<br />
+          It was almost impossible because the dream was so big<br />
+          That I didn&rsquo;t see any chance because
+        </p>
+        <p>
+          I was living in Porto Alegre, in the south of Brazil; was working as a consultant<br />
+          And all I really wanted to do was build products<br />
+          And not only build them, but make them grow by themselves
+        </p>
+        <p>
+          At that time, in 2015, we had a retrospective meeting, and the tool was so old<br />
+          So I would stay up at night after work, writing code with Firebase<br />
+          I built the first version in like one week<br />
+          And I said, &ldquo;Wait a second, I know the shareable link<br />
+          Why don&rsquo;t I use the shareable link, which is the growth of the future?&rdquo;<br />
+          So I gave every board a URL, no signup, no login,<br />
+          Which then was shared with whole teams around the world<br />
+          But I didn&rsquo;t realize how much the impact would be
+        </p>
+        <p>
+          In 2018 I quit my job, packed a backpack, and traveled the world<br />
+          Then in 2020 the whole world went remote<br />
+          And the users tripled in one week; half a million people<br />
+          Running retrospectives on a tool I built in one week, alone
+        </p>
+        <p>
+          My name is Glauber Ramos<br />
+          But everybody calls me @glauberamos
+        </p>
+        <p>
+          Once you free your mind about the concept of a company<br />
+          And of building a startup &ldquo;the right way&rdquo;<br />
+          You can do whatever you want<br />
+          So nobody told me what to build
+        </p>
+      </div>
+    </div>
+  </body>
+
+  <style>
+    * { box-sizing: border-box; }
+
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      background-color: rgb(18, 22, 32);
+      color: #e8eaf0;
+      margin: 0;
+      min-height: 100vh;
+      background-image:
+        radial-gradient(ellipse 80% 50% at 50% -10%, rgba(120, 90, 255, 0.14), transparent),
+        radial-gradient(ellipse 60% 40% at 80% 110%, rgba(255, 90, 160, 0.08), transparent);
+      background-attachment: fixed;
+    }
+
+    .page {
+      max-width: 34em;
+      margin: 0 auto;
+      padding: 1.8em 1.6em 2.4em;
+    }
+
+    h1 {
+      font-size: 1.7em;
+      margin: 0 0 1.2em;
+    }
+
+    .monologue p {
+      margin: 0 0 1.6em;
+      line-height: 1.75;
+      font-size: 0.98em;
+      color: rgba(232, 234, 240, 0.9);
+    }
+  </style>
+
+  <script>
+    /* =====================================================================
+       Music. Prefers /about/background.wav if you add one; otherwise plays
+       an original Web Audio synth loop inspired by "Giorgio by Moroder".
+       113 BPM, A minor. The parent desktop pauses/resumes it via
+       postMessage when the window is minimized, closed or restored.
+       ===================================================================== */
+    (function () {
+      var BPM = 113;
+      var STEP = 60 / BPM / 4;              /* one 16th note */
+      var LOOKAHEAD = 0.12;
+
+      /* One bar per chord, 4-bar loop: Am, F, C, G */
+      var ROOTS = [33, 29, 36, 31];
+      var PADS = [
+        [45, 48, 52],
+        [41, 45, 48],
+        [48, 52, 55],
+        [43, 47, 50]
+      ];
+      var BASS = [0, 0, 12, 0, 0, 12, 0, 0, 12, 0, 0, 12, 0, 0, 12, 0];
+      var VEL  = [1, .65, .9, .65, 1, .9, .65, .65, .9, .65, .65, .9, 1, .65, .9, .65];
+
+      var ctx = null, master, delayNode, noiseBuf;
+      var step = 0, nextTime = 0, timer = null;
+      var audioEl = null, mode = null;      /* 'file' | 'synth' */
+      var playing = false, wasPlaying = false, armed = false;
+
+      function midi(n) { return 440 * Math.pow(2, (n - 69) / 12); }
+
+      function init() {
+        ctx = new (window.AudioContext || window.webkitAudioContext)();
+
+        master = ctx.createGain();
+        master.gain.value = 0.4;
+        var comp = ctx.createDynamicsCompressor();
+        comp.threshold.value = -18;
+        comp.ratio.value = 4;
+        master.connect(comp);
+        comp.connect(ctx.destination);
+
+        /* dotted-8th echo — the signature Moroder bounce */
+        delayNode = ctx.createDelay(1);
+        delayNode.delayTime.value = STEP * 6;
+        var fb = ctx.createGain(); fb.gain.value = 0.3;
+        var wet = ctx.createGain(); wet.gain.value = 0.25;
+        delayNode.connect(fb); fb.connect(delayNode);
+        delayNode.connect(wet); wet.connect(master);
+
+        noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+        var d = noiseBuf.getChannelData(0);
+        for (var i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+      }
+
+      function bass(t, note, vel) {
+        var osc = ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.value = midi(note);
+        var f = ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.Q.value = 8;
+        f.frequency.setValueAtTime(1500 * vel, t);
+        f.frequency.exponentialRampToValueAtTime(220, t + 0.13);
+        var g = ctx.createGain();
+        g.gain.setValueAtTime(0.42 * vel, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + 0.16);
+        osc.connect(f); f.connect(g);
+        g.connect(master);
+        g.connect(delayNode);
+        osc.start(t); osc.stop(t + 0.2);
+      }
+
+      function kick(t) {
+        var osc = ctx.createOscillator();
+        osc.frequency.setValueAtTime(150, t);
+        osc.frequency.exponentialRampToValueAtTime(42, t + 0.11);
+        var g = ctx.createGain();
+        g.gain.setValueAtTime(0.9, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + 0.19);
+        osc.connect(g); g.connect(master);
+        osc.start(t); osc.stop(t + 0.2);
+      }
+
+      function hat(t, open) {
+        var src = ctx.createBufferSource();
+        src.buffer = noiseBuf;
+        var f = ctx.createBiquadFilter();
+        f.type = 'highpass';
+        f.frequency.value = 7500;
+        var g = ctx.createGain();
+        g.gain.setValueAtTime(open ? 0.22 : 0.11, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + (open ? 0.09 : 0.035));
+        src.connect(f); f.connect(g); g.connect(master);
+        src.start(t); src.stop(t + 0.1);
+      }
+
+      function clap(t) {
+        var src = ctx.createBufferSource();
+        src.buffer = noiseBuf;
+        var f = ctx.createBiquadFilter();
+        f.type = 'bandpass';
+        f.frequency.value = 1700;
+        f.Q.value = 0.9;
+        var g = ctx.createGain();
+        g.gain.setValueAtTime(0.3, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + 0.16);
+        src.connect(f); f.connect(g); g.connect(master);
+        src.start(t); src.stop(t + 0.2);
+      }
+
+      function pad(t, notes) {
+        var barLen = STEP * 16;
+        notes.forEach(function (n) {
+          [-6, 6].forEach(function (cents) {
+            var osc = ctx.createOscillator();
+            osc.type = 'sawtooth';
+            osc.frequency.value = midi(n);
+            osc.detune.value = cents;
+            var f = ctx.createBiquadFilter();
+            f.type = 'lowpass';
+            f.frequency.value = 850;
+            var g = ctx.createGain();
+            g.gain.setValueAtTime(0.0001, t);
+            g.gain.linearRampToValueAtTime(0.028, t + 0.4);
+            g.gain.setValueAtTime(0.028, t + barLen - 0.3);
+            g.gain.linearRampToValueAtTime(0.0001, t + barLen);
+            osc.connect(f); f.connect(g); g.connect(master);
+            osc.start(t); osc.stop(t + barLen + 0.05);
+          });
+        });
+      }
+
+      function lead(t, notes, s) {
+        var n = notes[s % notes.length] + 12;
+        var osc = ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = midi(n);
+        var f = ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.value = 2600;
+        var g = ctx.createGain();
+        g.gain.setValueAtTime(0.05, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + 0.12);
+        osc.connect(f); f.connect(g);
+        g.connect(master);
+        g.connect(delayNode);
+        osc.start(t); osc.stop(t + 0.15);
+      }
+
+      function schedule() {
+        while (nextTime < ctx.currentTime + LOOKAHEAD) {
+          var s = step % 16;
+          var bar = Math.floor(step / 16) % 4;
+          var loop = Math.floor(step / 64);
+          var root = ROOTS[bar];
+
+          bass(nextTime, root + BASS[s], VEL[s]);
+          if (s % 4 === 0) kick(nextTime);
+          hat(nextTime, s % 4 === 2);
+          if (s === 4 || s === 12) clap(nextTime);
+          if (s === 0) pad(nextTime, PADS[bar]);
+          if (loop % 2 === 1 && s % 2 === 0) lead(nextTime, PADS[bar], s / 2);
+
+          nextTime += STEP;
+          step += 1;
+        }
+      }
+
+      function startSynth() {
+        if (!ctx) init();
+        var begin = function () {
+          if (!timer) {
+            nextTime = Math.max(nextTime, ctx.currentTime + 0.05);
+            timer = setInterval(schedule, 25);
+          }
+          playing = true;
+        };
+        if (ctx.state === 'suspended') {
+          ctx.resume().then(function () {
+            if (ctx.state === 'running') begin();
+            else armClick();
+          }).catch(armClick);
+        } else {
+          begin();
+        }
+      }
+
+      function start() {
+        if (mode === 'synth') { startSynth(); return; }
+        if (!audioEl) {
+          /* plays background.mp3 or background.wav, whichever exists */
+          audioEl = document.createElement('audio');
+          ['background.mp3', 'background.wav'].forEach(function (f) {
+            var s = document.createElement('source');
+            s.src = f;
+            audioEl.appendChild(s);
+          });
+          audioEl.loop = true;
+          audioEl.volume = 0.8;
+        }
+        var p = audioEl.play();
+        if (p && p.then) {
+          p.then(function () {
+            mode = 'file';
+            playing = true;
+          }).catch(function (err) {
+            if (err && err.name === 'NotAllowedError') {
+              /* autoplay blocked — start on first interaction */
+              armClick();
+            } else {
+              /* no audio file — fall back to the synth loop */
+              mode = 'synth';
+              startSynth();
+            }
+          });
+        } else {
+          playing = true;
+        }
+      }
+
+      function stop() {
+        if (mode === 'file' && audioEl) audioEl.pause();
+        if (ctx && ctx.state === 'running') ctx.suspend();
+        playing = false;
+      }
+
+      function armClick() {
+        if (armed) return;
+        armed = true;
+        document.addEventListener('click', function () { start(); }, { once: true });
+      }
+
+      /* Parent desktop tells us when our window is minimized/closed/restored */
+      window.addEventListener('message', function (e) {
+        if (e.origin !== location.origin) return;
+        if (e.data === 'about:hide') { wasPlaying = playing; if (playing) stop(); }
+        else if (e.data === 'about:show') { if (wasPlaying) start(); }
+      });
+
+      window.addEventListener('load', function () { start(); });
+    })();
+  </script>
+</html>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
           <span class="desktop-icon-img" aria-hidden="true">🧱</span>
           <span class="desktop-icon-label">Breakout.exe</span>
         </button>
+        <button class="desktop-icon" type="button" data-open-window="win-about">
+          <span class="desktop-icon-img" aria-hidden="true">💿</span>
+          <span class="desktop-icon-label">About.exe</span>
+        </button>
       </div>
       <div class="window main-window" id="main-window" data-window data-persistent data-icon="🖥️" data-title="Glauber Ramos — Portfolio">
         <div class="title-bar" id="main-titlebar">
@@ -244,6 +248,23 @@
         </div>
       </div>
 
+      <div class="window app-window" id="win-about" data-window data-icon="💿" data-title="About" hidden>
+        <div class="title-bar">
+          <div class="title-bar-text">
+            <span class="title-bar-icon" aria-hidden="true">💿</span>
+            <span>About — About.exe</span>
+          </div>
+          <div class="title-bar-controls">
+            <button class="tb-btn" data-action="minimize" aria-label="Minimize">_</button>
+            <button class="tb-btn" data-action="maximize" aria-label="Maximize">□</button>
+            <button class="tb-btn close" data-action="close" aria-label="Close">×</button>
+          </div>
+        </div>
+        <div class="window-body app-body">
+          <iframe class="app-frame" data-src="/about" title="About" loading="lazy" allow="autoplay"></iframe>
+        </div>
+      </div>
+
       <div class="taskbar">
         <button class="start-button" id="start-button" aria-haspopup="true" aria-expanded="false" aria-controls="start-menu">
           <span class="start-flag" aria-hidden="true">
@@ -276,6 +297,7 @@
           <li><a href="https://imageai.app" target="_blank" rel="noopener"><span class="sm-icon" aria-hidden="true">🪄</span>Image AI</a></li>
           <li class="start-menu-sep" role="separator"></li>
           <li><a href="https://glauberramos.github.io/visited-countries" target="_blank" rel="noopener"><span class="sm-icon" aria-hidden="true">🌍</span>Visited Countries</a></li>
+          <li><a href="/about"><span class="sm-icon" aria-hidden="true">💿</span>About</a></li>
           <li class="start-menu-sep" role="separator"></li>
           <li><a href="http://www.twitter.com/glauberamos" target="_blank" rel="noopener"><span class="sm-icon" aria-hidden="true">🐦</span>Twitter</a></li>
           <li><a href="https://github.com/glauberramos" target="_blank" rel="noopener"><span class="sm-icon" aria-hidden="true">🐙</span>GitHub</a></li>
@@ -365,6 +387,15 @@
 
         function each(sel, ctx, fn){ Array.prototype.forEach.call((ctx||document).querySelectorAll(sel), fn); }
 
+        // Let iframe apps (About.exe music) react to their window being
+        // hidden or shown again.
+        function notifyFrame(s, msg){
+          var f = s.win.querySelector('iframe');
+          if (f && f.src && f.contentWindow){
+            try { f.contentWindow.postMessage(msg, location.origin); } catch (e) {}
+          }
+        }
+
         function bringToFront(s){
           zTop += 1;
           s.win.style.zIndex = zTop;
@@ -388,7 +419,12 @@
           return b;
         }
 
-        function show(s){ s.win.hidden = false; s.win.classList.remove('minimized'); s.minimized = false; }
+        function show(s){
+          s.win.hidden = false;
+          s.win.classList.remove('minimized');
+          s.minimized = false;
+          notifyFrame(s, 'about:show');
+        }
 
         function open(s){
           // Lazy-load any deferred iframe the first time the window opens.
@@ -413,12 +449,14 @@
           s.minimized = true;
           s.win.classList.add('minimized');
           if (s.item) s.item.classList.remove('active');
+          notifyFrame(s, 'about:hide');
         }
         function restore(s){
           show(s);
           bringToFront(s);
         }
         function close(s){
+          notifyFrame(s, 'about:hide');
           s.win.hidden = true;
           s.win.classList.remove('maximized', 'floating');
           s.win.style.cssText = '';


### PR DESCRIPTION
## What

- New **/about** page — a monologue in the structure of Daft Punk's *Giorgio by Moroder*, adapted to my real story (Porto Alegre, consulting, EasyRetro built in one week in 2015, nomad life in 2018, the 2020 remote-work explosion).
- **Music on open**: an original Web Audio synth loop (113 BPM, A minor — driving 16th-note bassline, four-on-the-floor kick, offbeat hats, pad and arp lead). If `about/background.mp3` or `about/background.wav` exists, the page plays that file instead.
- **💿 About.exe** desktop icon, app window (iframe popup) and Start menu entry.
- Music pauses when the window is minimized or closed, resumes on restore (postMessage from the window manager).
- If autoplay is blocked (direct visit to /about), the first click on the page starts the music.

## How to test

- Serve locally: `python3 -m http.server` then open http://localhost:8000 — click the **About.exe** desktop icon; music should start and the window should show the full monologue.
- Minimize/close the About window → music stops; restore → resumes.
- Visit http://localhost:8000/about/ directly → page renders, music starts on first click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)